### PR TITLE
feat: Implement user creation route

### DIFF
--- a/prisma/migrations/20241219195704_add_unique_constraint_to_email_in_users/migration.sql
+++ b/prisma/migrations/20241219195704_add_unique_constraint_to_email_in_users/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[email]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");

--- a/src/http/routes/create-user.ts
+++ b/src/http/routes/create-user.ts
@@ -1,0 +1,41 @@
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { hash } from 'bcryptjs'
+
+export const createUserRoute: FastifyPluginAsyncZod = async (app) => {
+  app.post(
+    '/users',
+    {
+      schema: {
+        body: z.object({
+          name: z.string().min(1, 'Name is required'),
+          email: z.string().email({ message: 'Invalid email format' }),
+          password: z.string().min(
+            6,
+            'Password must be at least 6 characters long'
+          ),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const { name, email, password } = request.body
+
+      const userWithSameEmail = await prisma.user.findUnique({
+        where: { email },
+      })
+
+      if (userWithSameEmail) {
+        return reply.status(409).send({ message: 'User already exists' })
+      }
+
+      const passwordHash = await hash(password, 6)
+
+      await prisma.user.create({
+        data: { name, email, password: passwordHash },
+      })
+
+      return reply.status(201).send()
+    }
+  )
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -7,6 +7,7 @@ import {
   type ZodTypeProvider
 } from 'fastify-type-provider-zod'
 import { env } from '@/env'
+import { createUserRoute } from './routes/create-user'
 
 const app = fastify().withTypeProvider<ZodTypeProvider>()
 
@@ -20,6 +21,8 @@ app.register(fastifyCors, {
 app.register(fastifyJwt, {
   secret: env.JWT_SECRET,
 })
+
+app.register(createUserRoute)
 
 app.listen({ port: 3333, host: '0.0.0.0' }).then(() => {
   console.log('HTTP server running!')


### PR DESCRIPTION
Implementa a rota `/users` (POST) para criar novos usuários. As seguintes funcionalidades foram adicionadas:

- **Requisição:** Exige os campos name, email e password.
- **Validação de dados:** Verifica se os campos obrigatórios estão preenchidos e se o formato do email é válido.
- **Hash de senha:** Cria um hash seguro da senha antes de armazená-la no banco de dados.
- **Prevenção de duplicidade:** Verifica se já existe um usuário com o mesmo email.
- **Resposta HTTP:** Retorna 201 (Created) se o usuário for criado com sucesso, ou 409 (Conflict) se o email já estiver em uso.