### PR TITLE
feat: Implement authentication middleware

### DIFF
--- a/src/http/routes/protected.ts
+++ b/src/http/routes/protected.ts
@@ -1,0 +1,14 @@
+import { ensureAuthenticated } from '@/middlewares/ensure-authenticated'
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+
+export const protectedRoute: FastifyPluginAsyncZod = async (app) => {
+  app.get(
+    '/protected',
+    {
+      onRequest: [ensureAuthenticated],
+    },
+    async (request, reply) => {
+      return reply.status(200).send({ message: 'Acesso concedido' })
+    }
+  )
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -9,6 +9,7 @@ import {
 import { env } from '@/env'
 import { createUserRoute } from './routes/create-user'
 import { authenticateRoute } from './routes/authenticate'
+import { protectedRoute } from './routes/protected'
 
 const app = fastify().withTypeProvider<ZodTypeProvider>()
 
@@ -21,11 +22,12 @@ app.register(fastifyCors, {
 
 app.register(fastifyJwt, {
   secret: env.JWT_SECRET,
-  sign: { expiresIn: '1h' },
+  sign: { expiresIn: '15m' },
 })
 
 app.register(createUserRoute)
 app.register(authenticateRoute)
+app.register(protectedRoute)
 
 app.listen({ port: 3333, host: '0.0.0.0' }).then(() => {
   console.log('HTTP server running!')

--- a/src/middlewares/ensure-authenticated.ts
+++ b/src/middlewares/ensure-authenticated.ts
@@ -1,0 +1,18 @@
+import { type FastifyReply, type FastifyRequest } from 'fastify'
+
+export async function ensureAuthenticated(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const token = request.headers.authorization?.replace(/^Bearer\s/, '')
+
+  if (!token) {
+    return reply.status(401).send({ message: 'Token is missing' })
+  }
+
+  try {
+    await request.jwtVerify()
+  } catch (error) {
+    return reply.status(401).send({ message: 'Token invalid' })
+  }
+}


### PR DESCRIPTION
Implementa o middleware `ensure-authenticated` para validar tokens JWT em todas as requisições protegidas. As seguintes funcionalidades foram implementadas:

- **Extração do token:** Extrai o token JWT do cabeçalho de autorização da requisição.
- **Validação do token:** Utiliza a função `request.jwtVerify()` para verificar a assinatura e a validade do token.
- **Resposta HTTP:** Retorna 401 (Unauthorized) caso o token seja inválido, esteja ausente ou ocorra qualquer outro erro durante a verificação.

**OBS:** a rota "protected", apenas foi criada para testar o middleware.