### PR TITLE
feat: Implement refresh token model and route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fastify/jwt": "^9.0.1",
         "@prisma/client": "^6.0.1",
         "bcryptjs": "^2.4.3",
+        "dayjs": "^1.11.13",
         "dotenv": "^16.4.7",
         "fastify": "^5.1.0",
         "fastify-type-provider-zod": "^4.0.2",
@@ -676,6 +677,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.4.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "server",
+  "name": "authentication-server",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -14,6 +14,7 @@
     "@fastify/jwt": "^9.0.1",
     "@prisma/client": "^6.0.1",
     "bcryptjs": "^2.4.3",
+    "dayjs": "^1.11.13",
     "dotenv": "^16.4.7",
     "fastify": "^5.1.0",
     "fastify-type-provider-zod": "^4.0.2",

--- a/prisma/migrations/20241226213127_create_refresh_token_model/migration.sql
+++ b/prisma/migrations/20241226213127_create_refresh_token_model/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "refresh_token" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "refresh_token_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "refresh_token_user_id_key" ON "refresh_token"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "refresh_token" ADD CONSTRAINT "refresh_token_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,11 +8,22 @@ datasource db {
 }
 
 model User {
-  id         String   @id @default(uuid())
-  name       String
-  email      String   @unique
-  password   String
-  created_at DateTime @default(now())
+  id            String        @id @default(uuid())
+  name          String
+  email         String        @unique
+  password      String
+  created_at    DateTime      @default(now())
+  refresh_token RefreshToken?
 
   @@map("users")
+}
+
+model RefreshToken {
+  id         String   @id @default(uuid())
+  user       User     @relation(fields: [user_id], references: [id])
+  user_id    String   @unique
+  created_at DateTime @default(now())
+  expires_at DateTime
+
+  @@map("refresh_token")
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 const envSchema = z.object({
   JWT_SECRET: z.string(),
+  DATABASE_URL: z.string(),
 })
 
 export const env = envSchema.parse(process.env)

--- a/src/http/routes/refresh-token.ts
+++ b/src/http/routes/refresh-token.ts
@@ -1,0 +1,48 @@
+import { prisma } from '@/lib/prisma'
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { z } from 'zod'
+import dayjs from 'dayjs'
+
+export const refreshTokenRoute: FastifyPluginAsyncZod = async (app) => {
+  app.post(
+    '/refresh-token',
+    {
+      schema: {
+        body: z.object({
+          refreshToken: z.string(),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const { refreshToken } = request.body
+
+      if (!refreshToken) {
+        return reply.status(401).send({ message: 'Refresh token is missing' })
+      }
+
+      try {
+        const { id } = app.jwt.verify(refreshToken) as { id: string }
+
+        const tokenEntry = await prisma.refreshToken.findUnique({
+          where: { id },
+        })
+
+        const isTokenExpired = dayjs().isAfter(dayjs(tokenEntry?.expires_at))
+
+        if (!tokenEntry || isTokenExpired) {
+          return reply.status(401).send({
+            message: 'Invalid or expired refresh token',
+          })
+        }
+
+        const token = app.jwt.sign({
+          user: { userId: tokenEntry.user_id },
+        })
+
+        return reply.status(200).send({ token })
+      } catch (error) {
+        return reply.status(401).send({ message: 'Invalid refresh token' })
+      }
+    }
+  )
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -9,6 +9,7 @@ import {
 import { env } from '@/env'
 import { createUserRoute } from './routes/create-user'
 import { authenticateRoute } from './routes/authenticate'
+import { refreshTokenRoute } from './routes/refresh-token'
 import { protectedRoute } from './routes/protected'
 
 const app = fastify().withTypeProvider<ZodTypeProvider>()
@@ -27,6 +28,7 @@ app.register(fastifyJwt, {
 
 app.register(createUserRoute)
 app.register(authenticateRoute)
+app.register(refreshTokenRoute)
 app.register(protectedRoute)
 
 app.listen({ port: 3333, host: '0.0.0.0' }).then(() => {


### PR DESCRIPTION
Implementa o model `RefreshToken`, a rota `/refresh-token` (POST) e a integração com a autenticação. As seguintes funcionalidades foram implementadas:

**Model RefreshToken:**

- Criado para armazenar e gerenciar refresh tokens no banco de dados.
- Inclui os campos `id`, `user_id`, `created_at` e `expires_at` para rastrear os tokens e suas datas de expiração.

**Rota /refresh-token:**

- **Requisição:** Exige o campo refreshToken.
- **Validação de dados:** Verifica se o refresh token está presente, se é um token válido e se não está expirado.
- **Resposta HTTP:** Retorna 200 (OK) com o novo access token, ou 401 (Unauthorized) caso a validação de dados falhe.

**Ajustes na rota authenticate:**

- Utiliza o método `upsert` para criar ou atualizar o registro de refresh token no banco de dados, garantindo que o `user_id` seja único e evitando duplicidade.
- Agora retorna um refresh token junto com o access token após a autenticação bem-sucedida.