### PR TITLE
feat: Implement logout route and adjust token generation in refresh-token route

### DIFF
--- a/src/http/routes/logout.ts
+++ b/src/http/routes/logout.ts
@@ -1,0 +1,35 @@
+import { prisma } from '@/lib/prisma'
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { z } from 'zod'
+
+export const logoutRoute: FastifyPluginAsyncZod = async (app) => {
+  app.post(
+    '/logout',
+    {
+      schema: {
+        body: z.object({
+          refreshToken: z.string(),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const { refreshToken } = request.body
+
+      if (!refreshToken) {
+        return reply.status(400).send({ message: 'Refresh token is missing' })
+      }
+
+      try {
+        const { id } = app.jwt.verify(refreshToken) as { id: string }
+
+        await prisma.refreshToken.delete({
+          where: { id },
+        })
+
+        return reply.status(200).send({ message: 'Logged out successfully' })
+      } catch (error) {
+        return reply.status(401).send({ message: 'Invalid refresh token' })
+      }
+    }
+  )
+}

--- a/src/http/routes/refresh-token.ts
+++ b/src/http/routes/refresh-token.ts
@@ -17,7 +17,7 @@ export const refreshTokenRoute: FastifyPluginAsyncZod = async (app) => {
       const { refreshToken } = request.body
 
       if (!refreshToken) {
-        return reply.status(401).send({ message: 'Refresh token is missing' })
+        return reply.status(400).send({ message: 'Refresh token is missing' })
       }
 
       try {
@@ -35,8 +35,16 @@ export const refreshTokenRoute: FastifyPluginAsyncZod = async (app) => {
           })
         }
 
+        const user = await prisma.user.findUnique({
+          where: { id: tokenEntry.user_id },
+        })
+
+        if (!user) {
+          return reply.status(401).send({ message: 'User not found' })
+        }
+
         const token = app.jwt.sign({
-          user: { userId: tokenEntry.user_id },
+          user: { id: user.id, name: user.name, email: user.email },
         })
 
         return reply.status(200).send({ token })

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -10,6 +10,7 @@ import { env } from '@/env'
 import { createUserRoute } from './routes/create-user'
 import { authenticateRoute } from './routes/authenticate'
 import { refreshTokenRoute } from './routes/refresh-token'
+import { logoutRoute } from './routes/logout'
 import { protectedRoute } from './routes/protected'
 
 const app = fastify().withTypeProvider<ZodTypeProvider>()
@@ -29,6 +30,7 @@ app.register(fastifyJwt, {
 app.register(createUserRoute)
 app.register(authenticateRoute)
 app.register(refreshTokenRoute)
+app.register(logoutRoute)
 app.register(protectedRoute)
 
 app.listen({ port: 3333, host: '0.0.0.0' }).then(() => {


### PR DESCRIPTION
Implementa a rota `/logout` (POST) e ajusta a geração de tokens na rota `/refresh-token`. As seguintes funcionalidades foram implementadas:

**Rota /logout:**
- **Requisição:** Exige o campo `refreshToken`.
- **Validação de dados:** Verifica se o refreshToken está presente e se é válido.
- **Operação:** Remove o `refreshToken` correspondente do banco de dados, invalidando a sessão do usuário.
- **Resposta HTTP:** 200 (OK): Logout realizado com sucesso. 401 (Unauthorized): Caso o `refreshToken` seja inválido. 400 (Bad request): Caso o `refreshToken` não seja encontrado.

**Ajustes na rota /refresh-token:**
- Adicionada uma consulta ao banco de dados para obter as informações completas do usuário (`id`, `name`, `email`) usando o `user_id` associado ao `refreshToken`.
- Agora o token gerado contém `id`, `name` e `email`, no mesmo formato do token retornado na rota de autenticação (`/sessions`).